### PR TITLE
Update fn clamp() in channel.rs to fix error[E0034]: multiple applica…

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -127,7 +127,7 @@ impl Channel for f64 {
 pub trait FloatChannel: Float + Channel {
     #[inline]
     fn saturate(self) -> Self {
-        self.clamp(zero(),one())
+        Channel::clamp(self, zero(), one())
     }
 }
 


### PR DESCRIPTION
…ble items in scope

error[E0034]: multiple applicable items in scope
    --> C:\Users\ksxmy\.cargo\git\checkouts\color-rs-aa80dce33bd75e44\c39c52a\src\channel.rs:130:14
     |
130  |         self.clamp(zero(),one())
     |              ^^^^^ multiple `clamp` found
     |
note: candidate #1 is defined in the trait `Channel`
    --> C:\Users\ksxmy\.cargo\git\checkouts\color-rs-aa80dce33bd75e44\c39c52a\src\channel.rs:31:5
     |
31   |     fn clamp(self, lo: Self, hi: Self) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: candidate #2 is defined in the trait `Float`
    --> C:\Users\ksxmy\.cargo\registry\src\index.crates.io-6f17d22bba15001f\num-traits-0.2.19\src\float.rs:1545:5
     |
1545 |     fn clamp(self, min: Self, max: Self) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: disambiguate the method for candidate #1
     |
130  |         Channel::clamp(self, zero(), one())
     |
help: disambiguate the method for candidate #2
     |
130  |         Float::clamp(self, zero(), one())
     |